### PR TITLE
Update browserslist data and normalize resume date dashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2398,9 +2398,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2415,7 +2415,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -8386,9 +8387,9 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
-      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true
     },
     "chai": {

--- a/public/resume.yaml
+++ b/public/resume.yaml
@@ -1,17 +1,17 @@
 experience:
   - position: "CEO / CTO"
     company: "Global Ujamaa / Durham, NC"
-    duration: "2026 - Present"
+    duration: "2026 – Present"
     details: "Provides enterprise-grade marketing technology strategy and leadership — built for growing businesses that aren’t enterprises yet."
 
   - position: "Solutions Architect"
     company: "Zoro, Inc. / Chicago, IL"
-    duration: "2022 - 2026"
+    duration: "2022 – 2026"
     details: "Provides holistic technology solution architectures across all areas of the marketing technology stack, including Customer Data Platform (CDP) strategy and implementation."
   
   - position: "Vice President, Technical Production"
     company: "Ketchum / New York, NY"
-    duration: "2021 - 2022"
+    duration: "2021 – 2022"
     details: "Delivered best-in-class client experiences and digital solutions."
   
   - position: "Director, Global Marketing Technology and Operations"


### PR DESCRIPTION
## Summary
Routine maintenance plus a small resume typography fix.

## Changes
- **Browserslist:** refreshed `caniuse-lite` via `npx update-browserslist-db@latest`. This silences the recurring *"caniuse-lite is 13 months old"* build warning. Reported **"No target browser changes"**, so there is no behavioral/output impact — lockfile only.
- **Resume:** normalized experience date ranges in `public/resume.yaml` to en-dashes (e.g. `2026 – Present`).

## Verification
- `npm run build` — succeeds, browserslist warning gone
- Tests unaffected (data-only resume change)

Co-Authored-By: Oz <oz-agent@warp.dev>